### PR TITLE
csgo_coachcommand: Add `.uncoach` command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ sudo: false
 addons:
     apt_packages:
         - lib32stdc++6  # needed for spcomp
+env:
+    - SMVERSION=1.9
 
 before_script:
     # install smbuilder
@@ -13,8 +15,9 @@ before_script:
     - cd ..
 
     # install the sourcemod compiler
-    - wget http://www.gsptalk.com/mirror/sourcemod/sourcemod-1.7.2-linux.tar.gz
-    - tar -xzf sourcemod-1.7.2-linux.tar.gz
+    - SMPACKAGE="http://sourcemod.net/latest.php?os=linux&version=${SMVERSION}"
+    - wget $SMPACKAGE
+    - tar xfz $(basename $SMPACKAGE)
     - cd addons/sourcemod/scripting/
     - chmod +x spcomp
     - PATH+=":$PWD"
@@ -34,6 +37,3 @@ before_script:
 
 script:
     - smbuilder --flags="-E"
-
-notifications:
-    email: false

--- a/scripting/csgo_coachcommand.sp
+++ b/scripting/csgo_coachcommand.sp
@@ -32,5 +32,6 @@ public void OnClientSayCommand_Post(int client, const char[] command, const char
   if (StrEqual(sArgs, ".uncoach", false)) {
     ChangeClientTeam(client, CS_TEAM_SPECTATOR);
     UpdateCoachTarget(client, 0);
+    PrintToChat(client, "You stopped coaching");
   }
 }

--- a/scripting/csgo_coachcommand.sp
+++ b/scripting/csgo_coachcommand.sp
@@ -29,4 +29,7 @@ public void OnClientSayCommand_Post(int client, const char[] command, const char
       PrintToChat(client, "Join CT or T first, then type .coach again");
     }
   }
+  if (StrEqual(sArgs, ".uncoach", false)) {
+    ChangeClientTeam(client, CS_TEAM_SPECTATOR);
+  }
 }

--- a/scripting/csgo_coachcommand.sp
+++ b/scripting/csgo_coachcommand.sp
@@ -31,5 +31,6 @@ public void OnClientSayCommand_Post(int client, const char[] command, const char
   }
   if (StrEqual(sArgs, ".uncoach", false)) {
     ChangeClientTeam(client, CS_TEAM_SPECTATOR);
+    UpdateCoachTarget(client, 0);
   }
 }

--- a/scripting/csgo_coachcommand.sp
+++ b/scripting/csgo_coachcommand.sp
@@ -33,5 +33,6 @@ public void OnClientSayCommand_Post(int client, const char[] command, const char
     ChangeClientTeam(client, CS_TEAM_SPECTATOR);
     UpdateCoachTarget(client, 0);
     PrintToChat(client, "You stopped coaching");
+    PrintToChatAll("%N has stopped coaching.", client);
   }
 }


### PR DESCRIPTION
Hello!
I've added the `.uncoach` command so instead of typing `coach` in the console or doing a retry, user can just type that to get back on spec mode.

Also updated `.travis.yml` as it is on https://github.com/splewis/csgo-pug-setup/blob/master/.travis.yml

Feel free to edit the branch 😄 